### PR TITLE
Documentation has a typo for script name ("kimsufi-chercker")

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Tool to check [Kimsufi (OVH)](https://www.kimsufi.com) availability and execute 
 
 ```sh
 $ pip3 install --user git+https://github.com/essembeh/kimsufi-checker
-$ kimsufi-chercker --help
+$ kimsufi-checker --help
 ```
 
 # Usage
 
 ```sh
-$ kimsufi-chercker --help
+$ kimsufi-checker --help
 usage: kimsufi-checker [-h] [-s SECONDS] [-z ZONE] [-x COMMAND] [-X COMMAND]
                        [plans [plans ...]]
 


### PR DESCRIPTION
I noticed a small typo in the documentation for the script name.

It said to run `kimsufi-chercker` which failed, but installation had been successful and I found the script at `~/.local/bin/kimsufi-checker`.
I didn't noticed the typo at first, so I thought it was a PATH issue... (which I also had...).

Anyway, here the small fix for other people to avoid running into this.

PS: I looked into the whole code: it was the only typos.